### PR TITLE
Added "relative" option to sails-linker task

### DIFF
--- a/tasks/scriptlinker.js
+++ b/tasks/scriptlinker.js
@@ -21,7 +21,8 @@ module.exports = function(grunt) {
 			startTag: '<!--SCRIPTS-->',
 			endTag: '<!--SCRIPTS END-->',
 			fileTmpl: '<script src="%s"></script>',
-			appRoot: ''
+			appRoot: '',
+			relative: false
 		});
 
 
@@ -41,7 +42,12 @@ module.exports = function(grunt) {
 						return false;
 					} else { return true; }
 				}).map(function (filepath) {
-					return util.format(options.fileTmpl, filepath.replace(options.appRoot, ''));
+					filepath = filepath.replace(options.appRoot, '');
+					// If "relative" option is set, remove initial forward slash from file path
+					if (options.relative) {
+						filepath = filepath.replace(/^\//,'');
+					}
+					return util.format(options.fileTmpl, filepath);
 				});
 
 			grunt.file.expand({}, f.dest).forEach(function(dest){


### PR DESCRIPTION
This will allow the linker task to output script and style tags with relative paths, so that the output from `sails build` can be easily used in a subdirectory (useful when building re-usable components).  The "relative" option can be placed in the top-level "sails-linker" config in a Grunt file if you want all of the subtasks (devJS, devStyles, etc.) to use relative paths, or in any of the individual subtasks for more granular control. 
