### PR TITLE
Search for end tag after start tag

### DIFF
--- a/tasks/scriptlinker.js
+++ b/tasks/scriptlinker.js
@@ -54,7 +54,7 @@ module.exports = function(grunt) {
 				page = grunt.file.read(dest);
 				start = page.indexOf(options.startTag);
 
-				end = page.indexOf(options.endTag);
+				end = page.indexOf(options.endTag, start);
 				if (start === -1 || end === -1 || start >= end) {
 					return;
 				} else {


### PR DESCRIPTION
There is no reason to search the hole file for the end tag and then just return if the end tag is before the start tag, It's better to just search for the tag after the index of the start tag.
This also fixes an issue we had with having the multiple instances of the same end tag in the file, so the script found the wrong tag and returned because the tag was before the start tag. 
