### PR TITLE
Switched from '\n' to grunt.util.linefeed so that generated line separat...

### DIFF
--- a/tasks/scriptlinker.js
+++ b/tasks/scriptlinker.js
@@ -28,7 +28,7 @@ module.exports = function(grunt) {
 
 		// Iterate over all specified file groups.
 		this.files.forEach(function (f) {
-			var scripts = '',
+			var scripts,
 				page = '',
 				newPage = '',
 				start = -1,
@@ -58,15 +58,15 @@ module.exports = function(grunt) {
 				if (start === -1 || end === -1 || start >= end) {
 					return;
 				} else {
-          var padding ='';
-          var ind = start - 1;
-          // TODO: Fix this hack
-          while(page.charAt(ind)===' ' || page.charAt(ind)==='  '){
-            padding += page.charAt(ind);
-            ind -= 1;
-          }
-          console.log('padding length', padding.length)
-					newPage = page.substr(0, start + options.startTag.length)+'\n' + padding + scripts.join('\n'+padding) + '\n' + padding + page.substr(end);
+				var padding ='';
+				var ind = start - 1;
+				// TODO: Fix this hack
+				while(page.charAt(ind)===' ' || page.charAt(ind)==='  '){
+					padding += page.charAt(ind);
+					ind -= 1;
+				}
+					console.log('padding length', padding.length);
+					newPage = page.substr(0, start + options.startTag.length) + grunt.util.linefeed + padding + scripts.join(grunt.util.linefeed + padding) + grunt.util.linefeed + padding + page.substr(end);
 					// Insert the scripts
 					grunt.file.write(dest, newPage);
 					grunt.log.writeln('File "' + dest + '" updated.');


### PR DESCRIPTION
Switched from '\n' to grunt.util.linefeed so that generated line separators would depend on current environment.

http://gruntjs.com/api/grunt.util#grunt.util.linefeed
