### PR TITLE
Fixed tag indentation hack

### DIFF
--- a/tasks/scriptlinker.js
+++ b/tasks/scriptlinker.js
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
 				} else {
 					var padding ='';
 					var ind = start - 1;
-					while(/[^\w\n]/.test(page.charAt(ind))){
+					while(/[^\S\n]/.test(page.charAt(ind))){
 						padding += page.charAt(ind);
 						ind -= 1;
 					}


### PR DESCRIPTION
This fix will allow arbitrary tabs and spaces in front of linker tags. In either template engine, .jade or .ejs, the linked resources and the end tag will align with the starting tag.
