### PR TITLE
Provide a task description in task-registration step using description f...

### DIFF
--- a/tasks/scriptlinker.js
+++ b/tasks/scriptlinker.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
 	// Please see the Grunt documentation for more information regarding task
 	// creation: http://gruntjs.com/creating-tasks
 
-	grunt.registerMultiTask('sails-linker', 'Your task description goes here.', function() {
+	grunt.registerMultiTask('sails-linker', 'Autoinsert script tags in an html file.', function() {
 		// Merge task-specific and/or target-specific options with these defaults.
 		var options = this.options({
 			startTag: '<!--SCRIPTS-->',


### PR DESCRIPTION
...rom package.json

This is a simple fix that provides more information about the task when running grunt with `-v`. The source for the text was taken verbatim from package.json.
