### PR TITLE
Update Gruntfile to use 'sails-linker' task name used when registering a...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -29,7 +29,7 @@ module.exports = function(grunt) {
     },
 
     // Configuration to be run (and then tested).
-    scriptlinker: {
+    'sails-linker': {
       default_options: {
         options: {
           startTag: '<!--SCRIPTS-->',
@@ -60,7 +60,7 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'scriptlinker:default_options', 'nodeunit']);
+  grunt.registerTask('test', ['clean', 'sails-linker:default_options', 'nodeunit']);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test']);


### PR DESCRIPTION
...ctual task

The task defined in tasks/scriptlinker.js registers itself as "sails-linker":

```
grunt.registerMultiTask('sails-linker', 'Your task description goes here.', function() {
    // Merge task-specific and/or target-specific options with these defaults.
    var options = this.options({
        startTag: '<!--SCRIPTS-->',
        endTag: '<!--SCRIPTS END-->',
        fileTmpl: '<script src="%s"></script>',
        appRoot: '',
        relative: false
    });
...
```

However, the `test` task in the Gruntfile looks for a 'scriptlinker' task: 

```
grunt.registerTask('test', ['clean', 'scriptlinker:default_options', 'nodeunit']);
```

This patch updates the Gruntfile to use the task name 'sails-linker' instead of 'scriptlinker' when defining default options and in the test task definition.
